### PR TITLE
pin gh actions to sha

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 16.x
 
@@ -46,7 +46,7 @@ jobs:
         id: diff
 
       # If index.js was different from expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - run: |
           npm install
       - run: |
@@ -19,7 +19,7 @@ jobs:
   test: # make sure the action works
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Upload with File
         uses: ./
@@ -35,7 +35,7 @@ jobs:
           disabled: false
           disableHome: true
           useLastFrame: true
-          buttonText: "Github Action App Start"
-          postSessionButtonText: "Restart Github Action App"
-          launchUrl: "https://appetize.io"
-          
+          buttonText: 'Github Action App Start'
+          postSessionButtonText: 'Restart Github Action App'
+          launchUrl: 'https://appetize.io'
+


### PR DESCRIPTION
the actual action doesn't use any 3rd party actions, but we have workflows for testing etc. so this updates those.